### PR TITLE
distsqlrun: generalize mergejoiner tests

### DIFF
--- a/pkg/sql/distsqlrun/hashjoiner_test.go
+++ b/pkg/sql/distsqlrun/hashjoiner_test.go
@@ -18,8 +18,6 @@ import (
 	"context"
 	"fmt"
 	math "math"
-	"sort"
-	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -230,37 +228,6 @@ func TestHashJoinerError(t *testing.T) {
 			}
 		})
 	}
-}
-
-func checkExpectedRows(
-	types []sqlbase.ColumnType, expectedRows sqlbase.EncDatumRows, results *RowBuffer,
-) error {
-	var expected []string
-	for _, row := range expectedRows {
-		expected = append(expected, row.String(types))
-	}
-	sort.Strings(expected)
-	expStr := strings.Join(expected, "")
-
-	var rets []string
-	for {
-		row, meta := results.Next()
-		if meta != nil {
-			return errors.Errorf("unexpected metadata: %v", meta)
-		}
-		if row == nil {
-			break
-		}
-		rets = append(rets, row.String(types))
-	}
-	sort.Strings(rets)
-	retStr := strings.Join(rets, "")
-
-	if expStr != retStr {
-		return errors.Errorf("invalid results; expected:\n   %s\ngot:\n   %s",
-			expStr, retStr)
-	}
-	return nil
 }
 
 // TestDrain tests that, if the consumer starts draining, the hashJoiner informs

--- a/pkg/sql/distsqlrun/mergejoiner_test.go
+++ b/pkg/sql/distsqlrun/mergejoiner_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"sort"
 )
 
 type mergeJoinerTestCase struct {
@@ -40,674 +41,52 @@ type mergeJoinerTestCase struct {
 func TestMergeJoiner(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	columnTypeInt := sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_INT}
-	v := [10]sqlbase.EncDatum{}
-	for i := range v {
-		v[i] = sqlbase.DatumToEncDatum(columnTypeInt, tree.NewDInt(tree.DInt(i)))
-	}
-	null := sqlbase.EncDatum{Datum: tree.DNull}
-
-	testCases := []mergeJoinerTestCase{
-		{
-			spec: MergeJoinerSpec{
-				LeftOrdering: convertToSpecOrdering(
-					sqlbase.ColumnOrdering{
-						{ColIdx: 0, Direction: encoding.Ascending},
-					}),
-				RightOrdering: convertToSpecOrdering(
-					sqlbase.ColumnOrdering{
-						{ColIdx: 0, Direction: encoding.Ascending},
-					}),
-				Type: sqlbase.InnerJoin,
-				// Implicit @1 = @3 constraint.
-			},
-			outCols:   []uint32{0, 3, 4},
-			leftTypes: twoIntCols,
-			leftInput: sqlbase.EncDatumRows{
-				{v[0], v[0]},
-				{v[1], v[4]},
-				{v[2], v[4]},
-				{v[3], v[1]},
-				{v[4], v[5]},
-				{v[5], v[5]},
-			},
-			rightTypes: threeIntCols,
-			rightInput: sqlbase.EncDatumRows{
-				{v[1], v[0], v[4]},
-				{v[3], v[4], v[1]},
-				{v[4], v[4], v[5]},
-			},
-			expectedTypes: threeIntCols,
-			expected: sqlbase.EncDatumRows{
-				{v[1], v[0], v[4]},
-				{v[3], v[4], v[1]},
-				{v[4], v[4], v[5]},
-			},
-		},
-		{
-			spec: MergeJoinerSpec{
-				LeftOrdering: convertToSpecOrdering(
-					sqlbase.ColumnOrdering{
-						{ColIdx: 0, Direction: encoding.Ascending},
-					}),
-				RightOrdering: convertToSpecOrdering(
-					sqlbase.ColumnOrdering{
-						{ColIdx: 0, Direction: encoding.Ascending},
-					}),
-				Type: sqlbase.InnerJoin,
-				// Implicit @1 = @3 constraint.
-			},
-			outCols:   []uint32{0, 1, 3},
-			leftTypes: twoIntCols,
-			leftInput: sqlbase.EncDatumRows{
-				{v[0], v[0]},
-				{v[0], v[1]},
-			},
-			rightTypes: twoIntCols,
-			rightInput: sqlbase.EncDatumRows{
-				{v[0], v[4]},
-				{v[0], v[1]},
-				{v[0], v[0]},
-				{v[0], v[5]},
-				{v[0], v[4]},
-			},
-			expectedTypes: threeIntCols,
-			expected: sqlbase.EncDatumRows{
-				{v[0], v[0], v[4]},
-				{v[0], v[0], v[1]},
-				{v[0], v[0], v[0]},
-				{v[0], v[0], v[5]},
-				{v[0], v[0], v[4]},
-				{v[0], v[1], v[4]},
-				{v[0], v[1], v[1]},
-				{v[0], v[1], v[0]},
-				{v[0], v[1], v[5]},
-				{v[0], v[1], v[4]},
-			},
-		},
-		{
-			spec: MergeJoinerSpec{
-				LeftOrdering: convertToSpecOrdering(
-					sqlbase.ColumnOrdering{
-						{ColIdx: 0, Direction: encoding.Ascending},
-					}),
-				RightOrdering: convertToSpecOrdering(
-					sqlbase.ColumnOrdering{
-						{ColIdx: 0, Direction: encoding.Ascending},
-					}),
-				Type:   sqlbase.InnerJoin,
-				OnExpr: Expression{Expr: "@4 >= 4"},
-				// Implicit AND @1 = @3 constraint.
-			},
-			outCols:   []uint32{0, 1, 3},
-			leftTypes: twoIntCols,
-			leftInput: sqlbase.EncDatumRows{
-				{v[0], v[0]},
-				{v[0], v[1]},
-				{v[1], v[0]},
-				{v[1], v[1]},
-			},
-			rightTypes: twoIntCols,
-			rightInput: sqlbase.EncDatumRows{
-				{v[0], v[4]},
-				{v[0], v[1]},
-				{v[0], v[0]},
-				{v[0], v[5]},
-				{v[0], v[4]},
-				{v[1], v[4]},
-				{v[1], v[1]},
-				{v[1], v[0]},
-				{v[1], v[5]},
-				{v[1], v[4]},
-			},
-			expectedTypes: threeIntCols,
-			expected: sqlbase.EncDatumRows{
-				{v[0], v[0], v[4]},
-				{v[0], v[0], v[5]},
-				{v[0], v[0], v[4]},
-				{v[0], v[1], v[4]},
-				{v[0], v[1], v[5]},
-				{v[0], v[1], v[4]},
-				{v[1], v[0], v[4]},
-				{v[1], v[0], v[5]},
-				{v[1], v[0], v[4]},
-				{v[1], v[1], v[4]},
-				{v[1], v[1], v[5]},
-				{v[1], v[1], v[4]},
-			},
-		},
-		{
-			spec: MergeJoinerSpec{
-				LeftOrdering: convertToSpecOrdering(
-					sqlbase.ColumnOrdering{
-						{ColIdx: 0, Direction: encoding.Ascending},
-					}),
-				RightOrdering: convertToSpecOrdering(
-					sqlbase.ColumnOrdering{
-						{ColIdx: 0, Direction: encoding.Ascending},
-					}),
-				Type:   sqlbase.FullOuterJoin,
-				OnExpr: Expression{Expr: "@2 >= @4"},
-				// Implicit AND @1 = @3 constraint.
-			},
-			outCols:   []uint32{0, 1, 3},
-			leftTypes: twoIntCols,
-			leftInput: sqlbase.EncDatumRows{
-				{v[0], v[0]},
-				{v[0], v[0]},
-
-				{v[1], v[5]},
-
-				{v[2], v[0]},
-				{v[2], v[8]},
-
-				{v[3], v[5]},
-
-				{v[6], v[0]},
-			},
-			rightTypes: twoIntCols,
-			rightInput: sqlbase.EncDatumRows{
-				{v[0], v[5]},
-				{v[0], v[5]},
-
-				{v[1], v[0]},
-				{v[1], v[8]},
-
-				{v[2], v[5]},
-
-				{v[3], v[0]},
-				{v[3], v[0]},
-
-				{v[5], v[0]},
-			},
-			expectedTypes: threeIntCols,
-			expected: sqlbase.EncDatumRows{
-				{v[0], v[0], null},
-				{v[0], v[0], null},
-				{null, null, v[5]},
-				{null, null, v[5]},
-
-				{v[1], v[5], v[0]},
-				{null, null, v[8]},
-
-				{v[2], v[0], null},
-				{v[2], v[8], v[5]},
-
-				{v[3], v[5], v[0]},
-				{v[3], v[5], v[0]},
-
-				{null, null, v[0]},
-
-				{v[6], v[0], null},
-			},
-		},
-		{
-			spec: MergeJoinerSpec{
-				LeftOrdering: convertToSpecOrdering(
-					sqlbase.ColumnOrdering{
-						{ColIdx: 0, Direction: encoding.Ascending},
-					}),
-				RightOrdering: convertToSpecOrdering(
-					sqlbase.ColumnOrdering{
-						{ColIdx: 0, Direction: encoding.Ascending},
-					}),
-				Type: sqlbase.LeftOuterJoin,
-				// Implicit @1 = @3 constraint.
-			},
-			outCols:   []uint32{0, 3, 4},
-			leftTypes: twoIntCols,
-			leftInput: sqlbase.EncDatumRows{
-				{v[0], v[0]},
-				{v[1], v[4]},
-				{v[2], v[4]},
-				{v[3], v[1]},
-				{v[4], v[5]},
-				{v[5], v[5]},
-			},
-			rightTypes: threeIntCols,
-			rightInput: sqlbase.EncDatumRows{
-				{v[1], v[0], v[4]},
-				{v[3], v[4], v[1]},
-				{v[4], v[4], v[5]},
-			},
-			expectedTypes: threeIntCols,
-			expected: sqlbase.EncDatumRows{
-				{v[0], null, null},
-				{v[1], v[0], v[4]},
-				{v[2], null, null},
-				{v[3], v[4], v[1]},
-				{v[4], v[4], v[5]},
-				{v[5], null, null},
-			},
-		},
-		{
-			spec: MergeJoinerSpec{
-				LeftOrdering: convertToSpecOrdering(
-					sqlbase.ColumnOrdering{
-						{ColIdx: 0, Direction: encoding.Ascending},
-					}),
-				RightOrdering: convertToSpecOrdering(
-					sqlbase.ColumnOrdering{
-						{ColIdx: 0, Direction: encoding.Ascending},
-					}),
-				Type: sqlbase.RightOuterJoin,
-				// Implicit @1 = @3 constraint.
-			},
-			outCols:   []uint32{3, 1, 2},
-			leftTypes: threeIntCols,
-			leftInput: sqlbase.EncDatumRows{
-				{v[1], v[0], v[4]},
-				{v[3], v[4], v[1]},
-				{v[4], v[4], v[5]},
-			},
-			rightTypes: twoIntCols,
-			rightInput: sqlbase.EncDatumRows{
-				{v[0], v[0]},
-				{v[1], v[4]},
-				{v[2], v[4]},
-				{v[3], v[1]},
-				{v[4], v[5]},
-				{v[5], v[5]},
-			},
-			expectedTypes: threeIntCols,
-			expected: sqlbase.EncDatumRows{
-				{v[0], null, null},
-				{v[1], v[0], v[4]},
-				{v[2], null, null},
-				{v[3], v[4], v[1]},
-				{v[4], v[4], v[5]},
-				{v[5], null, null},
-			},
-		},
-		{
-			spec: MergeJoinerSpec{
-				LeftOrdering: convertToSpecOrdering(
-					sqlbase.ColumnOrdering{
-						{ColIdx: 0, Direction: encoding.Ascending},
-					}),
-				RightOrdering: convertToSpecOrdering(
-					sqlbase.ColumnOrdering{
-						{ColIdx: 0, Direction: encoding.Ascending},
-					}),
-				Type: sqlbase.FullOuterJoin,
-				// Implicit @1 = @3 constraint.
-			},
-			outCols:   []uint32{0, 3, 4},
-			leftTypes: twoIntCols,
-			leftInput: sqlbase.EncDatumRows{
-				{v[0], v[0]},
-				{v[1], v[4]},
-				{v[2], v[4]},
-				{v[3], v[1]},
-				{v[4], v[5]},
-			},
-			rightTypes: threeIntCols,
-			rightInput: sqlbase.EncDatumRows{
-				{v[1], v[0], v[4]},
-				{v[3], v[4], v[1]},
-				{v[4], v[4], v[5]},
-				{v[5], v[5], v[1]},
-			},
-			expectedTypes: threeIntCols,
-			expected: sqlbase.EncDatumRows{
-				{v[0], null, null},
-				{v[1], v[0], v[4]},
-				{v[2], null, null},
-				{v[3], v[4], v[1]},
-				{v[4], v[4], v[5]},
-				{null, v[5], v[1]},
-			},
-		},
-		{
-			spec: MergeJoinerSpec{
-				LeftOrdering: convertToSpecOrdering(
-					sqlbase.ColumnOrdering{
-						{ColIdx: 0, Direction: encoding.Ascending},
-						{ColIdx: 1, Direction: encoding.Ascending},
-					}),
-				RightOrdering: convertToSpecOrdering(
-					sqlbase.ColumnOrdering{
-						{ColIdx: 0, Direction: encoding.Ascending},
-						{ColIdx: 1, Direction: encoding.Ascending},
-					}),
-				Type: sqlbase.FullOuterJoin,
-			},
-			outCols:   []uint32{0, 1, 2, 3},
-			leftTypes: twoIntCols,
-			leftInput: sqlbase.EncDatumRows{
-				{null, v[4]},
-				{v[0], null},
-				{v[0], v[1]},
-				{v[2], v[4]},
-			},
-			rightTypes: twoIntCols,
-			rightInput: sqlbase.EncDatumRows{
-				{null, v[4]},
-				{v[0], null},
-				{v[0], v[1]},
-				{v[2], v[4]},
-			},
-			expectedTypes: []sqlbase.ColumnType{intType, intType, intType, intType},
-			expected: sqlbase.EncDatumRows{
-				{null, v[4], null, null},
-				{null, null, null, v[4]},
-				{v[0], null, null, null},
-				{null, null, v[0], null},
-				{v[0], v[1], v[0], v[1]},
-				{v[2], v[4], v[2], v[4]},
-			},
-		},
-		{
-			// Ensure that NULL = NULL is not matched.
-			spec: MergeJoinerSpec{
-				LeftOrdering: convertToSpecOrdering(
-					sqlbase.ColumnOrdering{
-						{ColIdx: 0, Direction: encoding.Ascending},
-					}),
-				RightOrdering: convertToSpecOrdering(
-					sqlbase.ColumnOrdering{
-						{ColIdx: 0, Direction: encoding.Ascending},
-					}),
-				Type: sqlbase.InnerJoin,
-			},
-			outCols:   []uint32{0, 1},
-			leftTypes: oneIntCol,
-			leftInput: sqlbase.EncDatumRows{
-				{null},
-				{v[0]},
-			},
-			rightTypes: oneIntCol,
-			rightInput: sqlbase.EncDatumRows{
-				{null},
-				{v[1]},
-			},
-			expectedTypes: twoIntCols,
-			expected:      sqlbase.EncDatumRows{},
-		},
-		{
-			// Ensure that semi joins doesn't output duplicates from
-			// the right side.
-			spec: MergeJoinerSpec{
-				LeftOrdering: convertToSpecOrdering(
-					sqlbase.ColumnOrdering{
-						{ColIdx: 0, Direction: encoding.Ascending},
-					}),
-				RightOrdering: convertToSpecOrdering(
-					sqlbase.ColumnOrdering{
-						{ColIdx: 0, Direction: encoding.Ascending},
-					}),
-				Type: sqlbase.LeftSemiJoin,
-			},
-			outCols:   []uint32{0, 1},
-			leftTypes: twoIntCols,
-			leftInput: sqlbase.EncDatumRows{
-				{v[1], v[2]},
-				{v[2], v[3]},
-			},
-			rightTypes: twoIntCols,
-			rightInput: sqlbase.EncDatumRows{
-				{v[2], v[2]},
-				{v[2], v[2]},
-				{v[3], v[3]},
-			},
-			expectedTypes: twoIntCols,
-			expected: sqlbase.EncDatumRows{
-				{v[2], v[3]},
-			},
-		},
-		{
-			// Ensure that duplicate rows in the left are matched
-			// in the output in semi-joins.
-			spec: MergeJoinerSpec{
-				LeftOrdering: convertToSpecOrdering(
-					sqlbase.ColumnOrdering{
-						{ColIdx: 0, Direction: encoding.Ascending},
-					}),
-				RightOrdering: convertToSpecOrdering(
-					sqlbase.ColumnOrdering{
-						{ColIdx: 0, Direction: encoding.Ascending},
-					}),
-				Type: sqlbase.LeftSemiJoin,
-			},
-			outCols:   []uint32{0, 1},
-			leftTypes: twoIntCols,
-			leftInput: sqlbase.EncDatumRows{
-				{v[1], v[2]},
-				{v[1], v[2]},
-				{v[2], v[3]},
-				{v[3], v[4]},
-				{v[3], v[5]},
-			},
-			rightTypes: twoIntCols,
-			rightInput: sqlbase.EncDatumRows{
-				{v[2], v[2]},
-				{v[3], v[3]},
-			},
-			expectedTypes: twoIntCols,
-			expected: sqlbase.EncDatumRows{
-				{v[2], v[3]},
-				{v[3], v[4]},
-				{v[3], v[5]},
-			},
-		},
-		{
-			// Ensure that NULL == NULL doesn't match in semi-join.
-			spec: MergeJoinerSpec{
-				LeftOrdering: convertToSpecOrdering(
-					sqlbase.ColumnOrdering{
-						{ColIdx: 0, Direction: encoding.Ascending},
-					}),
-				RightOrdering: convertToSpecOrdering(
-					sqlbase.ColumnOrdering{
-						{ColIdx: 0, Direction: encoding.Ascending},
-					}),
-				Type: sqlbase.LeftSemiJoin,
-			},
-			outCols:   []uint32{0, 1},
-			leftTypes: twoIntCols,
-			leftInput: sqlbase.EncDatumRows{
-				{null, v[2]},
-				{v[2], v[3]},
-			},
-			rightTypes: twoIntCols,
-			rightInput: sqlbase.EncDatumRows{
-				{null, v[3]},
-				{v[2], v[4]},
-				{v[2], v[5]},
-			},
-			expectedTypes: twoIntCols,
-			expected: sqlbase.EncDatumRows{
-				{v[2], v[3]},
-			},
-		},
-		{
-			// Ensure that OnExprs are satisfied for semi-joins.
-			spec: MergeJoinerSpec{
-				LeftOrdering: convertToSpecOrdering(
-					sqlbase.ColumnOrdering{
-						{ColIdx: 0, Direction: encoding.Ascending},
-					}),
-				RightOrdering: convertToSpecOrdering(
-					sqlbase.ColumnOrdering{
-						{ColIdx: 0, Direction: encoding.Ascending},
-					}),
-				Type:   sqlbase.LeftSemiJoin,
-				OnExpr: Expression{Expr: "@1 >= 4"},
-				// Implicit AND @1 = @3 constraint.
-			},
-			outCols:   []uint32{0, 1},
-			leftTypes: twoIntCols,
-			leftInput: sqlbase.EncDatumRows{
-				{v[0], v[0]},
-				{v[0], v[1]},
-				{v[1], v[0]},
-				{v[1], v[1]},
-				{v[5], v[0]},
-				{v[5], v[1]},
-				{v[6], v[0]},
-				{v[6], v[1]},
-			},
-			rightTypes: twoIntCols,
-			rightInput: sqlbase.EncDatumRows{
-				{v[0], v[4]},
-				{v[0], v[1]},
-				{v[0], v[0]},
-				{v[0], v[5]},
-				{v[0], v[4]},
-				{v[5], v[4]},
-				{v[5], v[1]},
-				{v[5], v[0]},
-				{v[5], v[5]},
-				{v[5], v[4]},
-			},
-			expectedTypes: twoIntCols,
-			expected: sqlbase.EncDatumRows{
-				{v[5], v[0]},
-				{v[5], v[1]},
-			},
-		},
-		{
-			// Ensure that duplicate rows in the left are matched
-			// in the output in anti-joins.
-			spec: MergeJoinerSpec{
-				LeftOrdering: convertToSpecOrdering(
-					sqlbase.ColumnOrdering{
-						{ColIdx: 0, Direction: encoding.Ascending},
-					}),
-				RightOrdering: convertToSpecOrdering(
-					sqlbase.ColumnOrdering{
-						{ColIdx: 0, Direction: encoding.Ascending},
-					}),
-				Type: sqlbase.LeftAntiJoin,
-			},
-			outCols:   []uint32{0, 1},
-			leftTypes: twoIntCols,
-			leftInput: sqlbase.EncDatumRows{
-				{v[1], v[2]},
-				{v[1], v[3]},
-				{v[2], v[3]},
-				{v[3], v[4]},
-				{v[3], v[5]},
-			},
-			rightTypes: twoIntCols,
-			rightInput: sqlbase.EncDatumRows{
-				{v[2], v[2]},
-				{v[3], v[3]},
-			},
-			expectedTypes: twoIntCols,
-			expected: sqlbase.EncDatumRows{
-				{v[1], v[2]},
-				{v[1], v[3]},
-			},
-		},
-		{
-			// Ensure that NULL == NULL doesn't match in anti-join.
-			spec: MergeJoinerSpec{
-				LeftOrdering: convertToSpecOrdering(
-					sqlbase.ColumnOrdering{
-						{ColIdx: 0, Direction: encoding.Ascending},
-					}),
-				RightOrdering: convertToSpecOrdering(
-					sqlbase.ColumnOrdering{
-						{ColIdx: 0, Direction: encoding.Ascending},
-					}),
-				Type: sqlbase.LeftAntiJoin,
-			},
-			outCols:   []uint32{0, 1},
-			leftTypes: twoIntCols,
-			leftInput: sqlbase.EncDatumRows{
-				{null, v[2]},
-				{v[2], v[3]},
-			},
-			rightTypes: twoIntCols,
-			rightInput: sqlbase.EncDatumRows{
-				{null, v[3]},
-				{v[2], v[4]},
-				{v[2], v[5]},
-			},
-			expectedTypes: twoIntCols,
-			expected: sqlbase.EncDatumRows{
-				{null, v[2]},
-			},
-		},
-		{
-			// Ensure that OnExprs are satisfied for semi-joins.
-			spec: MergeJoinerSpec{
-				LeftOrdering: convertToSpecOrdering(
-					sqlbase.ColumnOrdering{
-						{ColIdx: 0, Direction: encoding.Ascending},
-					}),
-				RightOrdering: convertToSpecOrdering(
-					sqlbase.ColumnOrdering{
-						{ColIdx: 0, Direction: encoding.Ascending},
-					}),
-				Type:   sqlbase.LeftAntiJoin,
-				OnExpr: Expression{Expr: "@1 >= 4"},
-				// Implicit AND @1 = @3 constraint.
-			},
-			outCols:   []uint32{0, 1},
-			leftTypes: twoIntCols,
-			leftInput: sqlbase.EncDatumRows{
-				{v[0], v[0]},
-				{v[0], v[1]},
-				{v[1], v[0]},
-				{v[1], v[1]},
-				{v[5], v[0]},
-				{v[5], v[1]},
-				{v[6], v[0]},
-				{v[6], v[1]},
-			},
-			rightTypes: twoIntCols,
-			rightInput: sqlbase.EncDatumRows{
-				{v[0], v[4]},
-				{v[0], v[1]},
-				{v[0], v[0]},
-				{v[0], v[5]},
-				{v[0], v[4]},
-				{v[5], v[4]},
-				{v[5], v[1]},
-				{v[5], v[0]},
-				{v[5], v[5]},
-				{v[5], v[4]},
-			},
-			expectedTypes: twoIntCols,
-			expected: sqlbase.EncDatumRows{
-				{v[0], v[0]},
-				{v[0], v[1]},
-				{v[1], v[0]},
-				{v[1], v[1]},
-				{v[6], v[0]},
-				{v[6], v[1]},
-			},
-		},
-	}
+	testCases := joinerTestCases()
 
 	// Add INTERSECT ALL cases with MergeJoinerSpecs.
 	for _, tc := range intersectAllTestCases() {
-		testCases = append(testCases, setOpTestCaseToMergeJoinerTestCase(tc))
+		testCases = append(testCases, setOpTestCaseToJoinerTestCase(tc))
 	}
 
 	// Add EXCEPT ALL cases with MergeJoinerSpecs.
 	for _, tc := range exceptAllTestCases() {
-		testCases = append(testCases, setOpTestCaseToMergeJoinerTestCase(tc))
+		testCases = append(testCases, setOpTestCaseToJoinerTestCase(tc))
 	}
 
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {
-			ms := c.spec
+			st := cluster.MakeTestingClusterSettings()
+			evalCtx := tree.MakeTestingEvalContext(st)
+
+			// Ensure that test inputs are sorted on the equality columns.
+			sortInputByEqCols(c.leftInput, c.leftEqCols, c.leftTypes, &evalCtx)
+			sortInputByEqCols(c.rightInput, c.rightEqCols, c.rightTypes, &evalCtx)
+
 			leftInput := NewRowBuffer(c.leftTypes, c.leftInput, RowBufferArgs{})
 			rightInput := NewRowBuffer(c.rightTypes, c.rightInput, RowBufferArgs{})
 			out := &RowBuffer{}
-			st := cluster.MakeTestingClusterSettings()
-			evalCtx := tree.MakeTestingEvalContext(st)
 			defer evalCtx.Stop(context.Background())
 			flowCtx := FlowCtx{
 				Settings: st,
 				EvalCtx:  evalCtx,
 			}
 
+			leftOrdering := make(sqlbase.ColumnOrdering, len(c.leftEqCols))
+			for i, col := range c.leftEqCols {
+				leftOrdering[i] = sqlbase.ColumnOrderInfo{ColIdx: int(col), Direction: encoding.Ascending}
+			}
+			rightOrdering := make(sqlbase.ColumnOrdering, len(c.rightEqCols))
+			for i, col := range c.rightEqCols {
+				rightOrdering[i] = sqlbase.ColumnOrderInfo{ColIdx: int(col), Direction: encoding.Ascending}
+			}
+			ms := &MergeJoinerSpec{
+				LeftOrdering:  convertToSpecOrdering(leftOrdering),
+				RightOrdering: convertToSpecOrdering(rightOrdering),
+				Type:          c.joinType,
+				OnExpr:        c.onExpr,
+			}
 			post := PostProcessSpec{Projection: true, OutputColumns: c.outCols}
-			m, err := newMergeJoiner(&flowCtx, &ms, leftInput, rightInput, &post, out)
+			m, err := newMergeJoiner(&flowCtx, ms, leftInput, rightInput, &post, out)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -718,22 +97,43 @@ func TestMergeJoiner(t *testing.T) {
 				t.Fatalf("output RowReceiver not closed")
 			}
 
-			var retRows sqlbase.EncDatumRows
-			for {
-				row := out.NextNoMeta(t)
-				if row == nil {
-					break
-				}
-				retRows = append(retRows, row)
-			}
-			expStr := c.expected.String(c.expectedTypes)
-			retStr := retRows.String(c.expectedTypes)
-			if expStr != retStr {
-				t.Errorf("invalid results; expected:\n   %s\ngot:\n   %s",
-					expStr, retStr)
+			outTypes := m.OutputTypes()
+			if err := checkExpectedRows(outTypes, c.expected, out); err != nil {
+				t.Error(err)
 			}
 		})
 	}
+}
+
+func sortInputByEqCols(
+	input sqlbase.EncDatumRows,
+	eqCols []uint32,
+	types []sqlbase.ColumnType,
+	evalCtx *tree.EvalContext,
+) {
+	rowOrdering := make(sqlbase.ColumnOrdering, len(eqCols))
+	// Assume all test input is in ascending order.
+	for i, c := range eqCols {
+		rowOrdering[i] = sqlbase.ColumnOrderInfo{ColIdx: int(c), Direction: encoding.Ascending}
+	}
+	sorter := func(i, j int) bool {
+		da := &sqlbase.DatumAlloc{}
+		iEqualityCols := make(sqlbase.EncDatumRow, len(eqCols))
+		for k, col := range eqCols {
+			iEqualityCols[k] = input[i][col]
+		}
+		jEqualityCols := make(sqlbase.EncDatumRow, len(eqCols))
+		for k, col := range eqCols {
+			jEqualityCols[k] = input[j][col]
+		}
+		eqTypes := make([]sqlbase.ColumnType, len(c.leftEqCols))
+		for k, col := range eqCols {
+			eqTypes[k] = types[col]
+		}
+		cmp, _ := iEqualityCols.Compare(types, da, rowOrdering, evalCtx, jEqualityCols)
+		return cmp == -1
+	}
+	sort.Slice(input, sorter)
 }
 
 // Test that the joiner shuts down fine if the consumer is closed prematurely.

--- a/pkg/sql/distsqlrun/set_op_test.go
+++ b/pkg/sql/distsqlrun/set_op_test.go
@@ -17,7 +17,6 @@ package distsqlrun
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
-	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 )
 
 type setOpTestCase struct {
@@ -26,29 +25,6 @@ type setOpTestCase struct {
 	leftInput   sqlbase.EncDatumRows
 	rightInput  sqlbase.EncDatumRows
 	expected    sqlbase.EncDatumRows
-}
-
-func setOpTestCaseToMergeJoinerTestCase(tc setOpTestCase) mergeJoinerTestCase {
-	spec := MergeJoinerSpec{Type: tc.setOpType}
-	ordering := make(sqlbase.ColumnOrdering, 0, len(tc.columnTypes))
-	outCols := make([]uint32, 0, len(tc.columnTypes))
-	for i := range tc.columnTypes {
-		ordering = append(ordering, sqlbase.ColumnOrderInfo{ColIdx: i, Direction: encoding.Ascending})
-		outCols = append(outCols, uint32(i))
-	}
-	spec.LeftOrdering = convertToSpecOrdering(ordering)
-	spec.RightOrdering = convertToSpecOrdering(ordering)
-
-	return mergeJoinerTestCase{
-		spec:          spec,
-		outCols:       outCols,
-		leftTypes:     tc.columnTypes,
-		leftInput:     tc.leftInput,
-		rightTypes:    tc.columnTypes,
-		rightInput:    tc.rightInput,
-		expectedTypes: tc.columnTypes,
-		expected:      tc.expected,
-	}
 }
 
 func setOpTestCaseToJoinerTestCase(tc setOpTestCase) joinerTestCase {


### PR DESCRIPTION
Factor out the merge joiner test cases into a general joiner test case.
Now the {hash,merge}joiners run eachothers tests as well as their own
from the general joiner test case repository.

Release note: None